### PR TITLE
Makes the URL prompt more user friendly

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-read -p "Enter the URL from email: " PRESIGNED_URL
+read -p "Enter the download URL (copy in email): " PRESIGNED_URL
 echo ""
 read -p "Enter the list of models to download without spaces (7B,13B,70B,7B-chat,13B-chat,70B-chat), or press Enter for all: " MODEL_SIZE
 TARGET_FOLDER="."             # where all files should end up


### PR DESCRIPTION
Previously it was "Enter the URL from the email:" and that had a bunch of folks confused and they were just entering their email (because autopilot).

This commit removes that possible disambiguation.